### PR TITLE
ADIOS VCS composer url

### DIFF
--- a/book/content/pages/contribute.md
+++ b/book/content/pages/contribute.md
@@ -15,14 +15,6 @@ In following steps, we assume you have forked Hubleto to the folder named `huble
 > **IMPORTANT, DO NOT SKIP** To officially become a contributor, you must sign the [Individual Contributor License Agreement (ICLA)](licenses/contributor/individual). See [this article](licenses/contributor/individual) on how to sign. **If you do not sign ICLA, your pull requests will not be accepted.**
 > If you are representing a company or a corporation, you also must sign [Corporate Contributor License Agreement (CCLA)](licenses/contributor/corporate).
 
-## Clone ADIOS framework
-
-Hubleto uses [ADIOS framework](https://github.com/wai-blue/adios). Clone it to any folder under your webserver's document root.
-
-```
-git clone https://github.com/wai-blue/adios
-```
-
 ## Create composer-dev.json file
 
 In your Hubleto root folder, create a `composer-dev.json` file:
@@ -52,12 +44,14 @@ In your Hubleto root folder, create a `composer-dev.json` file:
     },
     "repositories": [
         {
-            "type": "path",
-            "url": "../../github/adios" <-- add your path here
+            "type": "vcs",
+            "url": "https://github.com/wai-blue/adios.git"
         }
     ]
 }
 ```
+
+> Hubleto is strongly based on the underlying ADIOS Framework. In many cases, it is also beneficial to make a local clone of the [ADIOS Framework](https://github.com/wai-blue/adios), as many changes require updates there. However, for the sake of simplicity, the process of cloning it has been omitted from this guide.
 
 ## Initialize Hubleto project
 

--- a/composer-dev.sh
+++ b/composer-dev.sh
@@ -1,0 +1,3 @@
+#/usr/bin/bash
+
+env COMPOSER=composer-dev.json composer --no-interaction $1

--- a/composer-dev.sh
+++ b/composer-dev.sh
@@ -1,3 +1,3 @@
-#/usr/bin/bash
+#!/usr/bin/bash
 
 env COMPOSER=composer-dev.json composer --no-interaction $1


### PR DESCRIPTION
Copilot summary below.

This pull request includes changes to the `book/content/pages/contribute.md` file and the addition of a new script `composer-dev.sh`. The changes aim to simplify the contribution guide and add a new script for handling composer commands.

Simplification of contribution guide:

* Removed the section on cloning the ADIOS framework from the contribution guide to streamline the process.
* Updated the repository type and URL in the `composer-dev.json` example to use the VCS type and point to the ADIOS GitHub repository. Added a note about the importance of the ADIOS framework and the optional step of cloning it locally.

Addition of new script:

* Added a new script `composer-dev.sh` to simplify running composer commands with the `composer-dev.json` file on Linux as well