### PR TITLE
Added a brief documentation for Calendar Sync

### DIFF
--- a/book/content/pages/apps/community/calendar-sync.md
+++ b/book/content/pages/apps/community/calendar-sync.md
@@ -1,0 +1,26 @@
+# CalendarSync
+
+CalendarSync is a community app that allows you to link external calendars to Hubleto.
+
+**Currently supported sources of calendars:**
+- Google Calendar
+- ICS file URL
+- Additions are more than welcome!
+
+## Usage
+
+After installing CalendarSync, it will not be added to the sidebar. Instead, you will find it in the settings. Visit
+the settings and look for an item named `Calendar sources`. After clicking the link, you will be greeted with a basic
+information overview about the extension. In the left sidebar, you can then select which calendar source you want to
+manage. You can either add new ones or select an existing one of that type and edit or delete it. All changes
+automatically take effect, just make sure that your sources are marked as active.
+
+## Google Calendar Integration
+
+To use Google Calendar, you have to define an API key in the ConfigEnv.php of your app like so:
+```php
+$config['google-api-key'] = "..."
+```
+
+To get your API key, visit this guide: [support.google.com](https://support.google.com/googleapi/answer/6158862?hl=en) \
+And make sure that the API key has access to the calendars you use or that the calendars you use are made public.


### PR DESCRIPTION
Added a brief guide on how to use Calendar Sync and how to configure it.

This pull request adds a new community app called CalendarSync to the documentation. The most important changes include a detailed description of the app, its usage, and instructions for integrating Google Calendar.

Documentation updates:

* [`book/content/pages/apps/community/calendar-sync.md`](diffhunk://#diff-6b9f85281a3483d5fe75e664f0e46f1542bf3b126770fc594cb427258264cbd1R1-R26): Added a new section for CalendarSync, including an overview of the app, supported calendar sources, usage instructions, and steps for integrating Google Calendar with an API key.