### PR TITLE
redesign sidebars, menu, and sidebar search

### DIFF
--- a/v0/book/content/pages/docs/erp.md
+++ b/v0/book/content/pages/docs/erp.md
@@ -2,7 +2,7 @@
 
 <div class="grid gap-4 mt-8 md:grid-cols-2">
   <div class="card border-yellow-300">
-    <div class="card-header bg-yellow-50">Apps</div>
+    <div class="card-header bg-yellow-800 text-yellow-200">Apps</div>
     <div class="card-body flex flex-col gap-2">
       <a href="erp/apps" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="erp/apps/folder-structure" class="btn btn-white block"><span class="text">Folder structure</span></a>
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div class="card border-stone-300">
-    <div class="card-header bg-stone-50">Misellaneous</div>
+    <div class="card-header bg-stone-700 text-stone-200">Misellaneous</div>
     <div class="card-body flex flex-col gap-2">
       <a href="erp/conventions" class="btn btn-white block"><span class="text">Conventions</span></a>
       <a href="erp/localization" class="btn btn-white block"><span class="text">Localization</span></a>

--- a/v0/book/content/pages/docs/erp/advanced-development/core-architecture.md
+++ b/v0/book/content/pages/docs/erp/advanced-development/core-architecture.md
@@ -67,7 +67,7 @@ In following chapters, we will learn how default features of Hubleto are impleme
 
 <div class="mt-8 grid gap-8 md:grid-cols-2">
   <div class="card border-yellow-300">
-    <div class="card-header bg-yellow-50">Hubleto Core</div>
+    <div class="card-header bg-yellow-800 text-yellow-200">Hubleto Core</div>
     <div class="card-body flex flex-col gap-2">
       <a href="#" class="btn btn-white block"><span class="text">User interface</span></a>
       <a href="core-architecture/user-management-and-authentication" class="btn btn-white block"><span class="text">User management and authentication</span></a>
@@ -77,7 +77,7 @@ In following chapters, we will learn how default features of Hubleto are impleme
     </div>
   </div>
   <div class="card border-green-300">
-    <div class="card-header bg-green-50">Hubleto App</div>
+    <div class="card-header bg-green-900 text-green-200">Hubleto App</div>
     <div class="card-body flex flex-col gap-2">
       <a href="#" class="btn btn-white block"><span class="text">Loader</span></a>
       <a href="#" class="btn btn-white block"><span class="text">Models, views & controllers</span></a>

--- a/v0/book/content/pages/docs/framework.md
+++ b/v0/book/content/pages/docs/framework.md
@@ -113,7 +113,7 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
 
 <div class="grid gap-4 mt-8 md:grid-cols-2">
   <div class="card border-yellow-300">
-    <div class="card-header bg-yellow-50">Routing</div>
+    <div class="card-header bg-yellow-800 text-yellow-200">Routing</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/routing" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/routing/defining-routes" class="btn btn-white block"><span class="text">Defining routes</span></a>
@@ -122,7 +122,7 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
     </div>
   </div>
   <div class="card border-green-300">
-    <div class="card-header bg-green-50">Models</div>
+    <div class="card-header bg-green-900 text-green-200">Models</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/models" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/models/columns" class="btn btn-white block"><span class="text">Columns</span></a>
@@ -133,7 +133,7 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
     </div>
   </div>
   <div class="card border-blue-300">
-    <div class="card-header bg-blue-50">Views</div>
+    <div class="card-header bg-blue-900 text-blue-200">Views</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/views" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/views/namespaces" class="btn btn-white block"><span class="text">Namespaces</span></a>
@@ -141,7 +141,7 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
     </div>
   </div>
   <div class="card border-stone-300">
-    <div class="card-header bg-stone-50">Controllers</div>
+    <div class="card-header bg-stone-700 text-stone-200">Controllers</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/controllers" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/controllers/html-output" class="btn btn-white block"><span class="text">HTML output</span></a>
@@ -149,7 +149,7 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
     </div>
   </div>
   <div class="card border-stone-300">
-    <div class="card-header bg-stone-50">UI</div>
+    <div class="card-header bg-stone-700 text-stone-200">UI</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/ui" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/ui/creating-components" class="btn btn-white block"><span class="text">Creating custom components</span></a>
@@ -159,7 +159,7 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
     </div>
   </div>
   <div class="card border-yellow-300">
-    <div class="card-header bg-yellow-50">Apps</div>
+    <div class="card-header bg-yellow-800 text-yellow-200">Apps</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/apps" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/apps/folder-structure" class="btn btn-white block"><span class="text">Folder structure</span></a>
@@ -169,13 +169,13 @@ Ready to learn Hubleto Framework? Good choice. Go through these pages and become
     </div>
   </div>
   <div class="card border-stone-300">
-    <div class="card-header bg-stone-50">Extendibles</div>
+    <div class="card-header bg-stone-700 text-stone-200">Extendibles</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/extendibles" class="btn btn-white block"><span class="text">Introduction</span></a>
     </div>
   </div>
   <div class="card border-stone-300">
-    <div class="card-header bg-stone-50">Testing</div>
+    <div class="card-header bg-stone-700 text-stone-200">Testing</div>
     <div class="card-body flex flex-col gap-2">
       <a href="framework/testing" class="btn btn-white block"><span class="text">Introduction</span></a>
       <a href="framework/testing/writing-tests" class="btn btn-white block"><span class="text">Writing tests</span></a>

--- a/v0/template/assets/css/book.css
+++ b/v0/template/assets/css/book.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.2.4 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities, theme, components, app;
 :root, :host {
@@ -11,75 +11,79 @@
   --radius-4xl: 2rem;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
-  --color-red-100: oklch(0.936 0.032 17.717);
-  --color-red-200: oklch(0.885 0.062 18.334);
-  --color-red-400: oklch(0.704 0.191 22.216);
-  --color-red-600: oklch(0.577 0.245 27.325);
-  --color-red-800: oklch(0.444 0.177 26.899);
-  --color-red-950: oklch(0.258 0.092 26.042);
-  --color-amber-100: oklch(0.962 0.059 95.617);
-  --color-amber-300: oklch(0.879 0.169 91.605);
-  --color-amber-600: oklch(0.666 0.179 58.318);
-  --color-yellow-50: oklch(0.987 0.026 102.212);
-  --color-yellow-100: oklch(0.973 0.071 103.193);
-  --color-yellow-200: oklch(0.945 0.129 101.54);
-  --color-yellow-300: oklch(0.905 0.182 98.111);
-  --color-yellow-600: oklch(0.681 0.162 75.834);
-  --color-yellow-800: oklch(0.476 0.114 61.907);
-  --color-yellow-950: oklch(0.286 0.066 53.813);
-  --color-lime-50: oklch(0.986 0.031 120.757);
-  --color-lime-100: oklch(0.967 0.067 122.328);
-  --color-lime-200: oklch(0.938 0.127 124.321);
-  --color-lime-600: oklch(0.648 0.2 131.684);
-  --color-lime-800: oklch(0.453 0.124 130.933);
-  --color-green-50: oklch(0.982 0.018 155.826);
-  --color-green-100: oklch(0.962 0.044 156.743);
-  --color-green-200: oklch(0.925 0.084 155.995);
-  --color-green-300: oklch(0.871 0.15 154.449);
-  --color-green-600: oklch(0.627 0.194 149.214);
-  --color-green-700: oklch(0.527 0.154 150.069);
-  --color-green-800: oklch(0.448 0.119 151.328);
-  --color-green-900: oklch(0.393 0.095 152.535);
-  --color-green-950: oklch(0.266 0.065 152.934);
-  --color-sky-50: oklch(0.977 0.013 236.62);
-  --color-sky-600: oklch(0.588 0.158 241.966);
-  --color-blue-50: oklch(0.97 0.014 254.604);
-  --color-blue-100: oklch(0.932 0.032 255.585);
-  --color-blue-200: oklch(0.882 0.059 254.128);
-  --color-blue-300: oklch(0.809 0.105 251.813);
-  --color-blue-400: oklch(0.707 0.165 254.624);
-  --color-blue-500: oklch(0.623 0.214 259.815);
-  --color-blue-600: oklch(0.546 0.245 262.881);
-  --color-blue-800: oklch(0.424 0.199 265.638);
-  --color-blue-900: oklch(0.379 0.146 265.522);
-  --color-blue-950: oklch(0.282 0.091 267.935);
-  --color-violet-50: oklch(0.969 0.016 293.756);
-  --color-violet-100: oklch(0.943 0.029 294.588);
-  --color-violet-200: oklch(0.894 0.057 293.283);
-  --color-violet-600: oklch(0.541 0.281 293.009);
-  --color-violet-800: oklch(0.432 0.232 292.759);
-  --color-slate-50: oklch(0.984 0.003 247.858);
-  --color-slate-100: oklch(0.968 0.007 247.896);
-  --color-slate-200: oklch(0.929 0.013 255.508);
-  --color-slate-300: oklch(0.869 0.022 252.894);
-  --color-slate-400: oklch(0.704 0.04 256.788);
-  --color-slate-500: oklch(0.554 0.046 257.417);
-  --color-slate-900: oklch(0.208 0.042 265.755);
-  --color-gray-50: oklch(0.985 0.002 247.839);
-  --color-gray-100: oklch(0.967 0.003 264.542);
-  --color-gray-200: oklch(0.928 0.006 264.531);
-  --color-gray-300: oklch(0.872 0.01 258.338);
-  --color-gray-400: oklch(0.707 0.022 261.325);
-  --color-gray-500: oklch(0.551 0.027 264.364);
-  --color-gray-600: oklch(0.446 0.03 256.802);
-  --color-gray-700: oklch(0.373 0.034 259.733);
-  --color-gray-800: oklch(0.278 0.033 256.848);
-  --color-gray-900: oklch(0.21 0.034 264.665);
-  --color-gray-950: oklch(0.13 0.028 261.692);
-  --color-stone-50: oklch(0.985 0.001 106.423);
-  --color-stone-200: oklch(0.923 0.003 48.717);
-  --color-stone-300: oklch(0.869 0.005 56.366);
-  --color-stone-700: oklch(0.374 0.01 67.558);
+  --color-red-100: oklch(93.6% 0.032 17.717);
+  --color-red-200: oklch(88.5% 0.062 18.334);
+  --color-red-400: oklch(70.4% 0.191 22.216);
+  --color-red-600: oklch(57.7% 0.245 27.325);
+  --color-red-800: oklch(44.4% 0.177 26.899);
+  --color-red-950: oklch(25.8% 0.092 26.042);
+  --color-amber-100: oklch(96.2% 0.059 95.617);
+  --color-amber-200: oklch(92.4% 0.12 95.746);
+  --color-amber-300: oklch(87.9% 0.169 91.605);
+  --color-amber-400: oklch(82.8% 0.189 84.429);
+  --color-amber-500: oklch(76.9% 0.188 70.08);
+  --color-amber-600: oklch(66.6% 0.179 58.318);
+  --color-amber-800: oklch(47.3% 0.137 46.201);
+  --color-amber-950: oklch(27.9% 0.077 45.635);
+  --color-yellow-50: oklch(98.7% 0.026 102.212);
+  --color-yellow-100: oklch(97.3% 0.071 103.193);
+  --color-yellow-200: oklch(94.5% 0.129 101.54);
+  --color-yellow-300: oklch(90.5% 0.182 98.111);
+  --color-yellow-600: oklch(68.1% 0.162 75.834);
+  --color-yellow-800: oklch(47.6% 0.114 61.907);
+  --color-yellow-950: oklch(28.6% 0.066 53.813);
+  --color-lime-50: oklch(98.6% 0.031 120.757);
+  --color-lime-100: oklch(96.7% 0.067 122.328);
+  --color-lime-200: oklch(93.8% 0.127 124.321);
+  --color-lime-600: oklch(64.8% 0.2 131.684);
+  --color-lime-800: oklch(45.3% 0.124 130.933);
+  --color-green-50: oklch(98.2% 0.018 155.826);
+  --color-green-100: oklch(96.2% 0.044 156.743);
+  --color-green-200: oklch(92.5% 0.084 155.995);
+  --color-green-300: oklch(87.1% 0.15 154.449);
+  --color-green-600: oklch(62.7% 0.194 149.214);
+  --color-green-700: oklch(52.7% 0.154 150.069);
+  --color-green-800: oklch(44.8% 0.119 151.328);
+  --color-green-900: oklch(39.3% 0.095 152.535);
+  --color-green-950: oklch(26.6% 0.065 152.934);
+  --color-sky-50: oklch(97.7% 0.013 236.62);
+  --color-sky-600: oklch(58.8% 0.158 241.966);
+  --color-blue-50: oklch(97% 0.014 254.604);
+  --color-blue-100: oklch(93.2% 0.032 255.585);
+  --color-blue-200: oklch(88.2% 0.059 254.128);
+  --color-blue-300: oklch(80.9% 0.105 251.813);
+  --color-blue-400: oklch(70.7% 0.165 254.624);
+  --color-blue-500: oklch(62.3% 0.214 259.815);
+  --color-blue-600: oklch(54.6% 0.245 262.881);
+  --color-blue-800: oklch(42.4% 0.199 265.638);
+  --color-blue-900: oklch(37.9% 0.146 265.522);
+  --color-blue-950: oklch(28.2% 0.091 267.935);
+  --color-violet-50: oklch(96.9% 0.016 293.756);
+  --color-violet-100: oklch(94.3% 0.029 294.588);
+  --color-violet-200: oklch(89.4% 0.057 293.283);
+  --color-violet-600: oklch(54.1% 0.281 293.009);
+  --color-violet-800: oklch(43.2% 0.232 292.759);
+  --color-slate-50: oklch(98.4% 0.003 247.858);
+  --color-slate-100: oklch(96.8% 0.007 247.896);
+  --color-slate-200: oklch(92.9% 0.013 255.508);
+  --color-slate-300: oklch(86.9% 0.022 252.894);
+  --color-slate-400: oklch(70.4% 0.04 256.788);
+  --color-slate-500: oklch(55.4% 0.046 257.417);
+  --color-slate-900: oklch(20.8% 0.042 265.755);
+  --color-gray-50: oklch(98.5% 0.002 247.839);
+  --color-gray-100: oklch(96.7% 0.003 264.542);
+  --color-gray-200: oklch(92.8% 0.006 264.531);
+  --color-gray-300: oklch(87.2% 0.01 258.338);
+  --color-gray-400: oklch(70.7% 0.022 261.325);
+  --color-gray-500: oklch(55.1% 0.027 264.364);
+  --color-gray-600: oklch(44.6% 0.03 256.802);
+  --color-gray-700: oklch(37.3% 0.034 259.733);
+  --color-gray-800: oklch(27.8% 0.033 256.848);
+  --color-gray-900: oklch(21% 0.034 264.665);
+  --color-gray-950: oklch(13% 0.028 261.692);
+  --color-stone-200: oklch(92.3% 0.003 48.717);
+  --color-stone-300: oklch(86.9% 0.005 56.366);
+  --color-stone-700: oklch(37.4% 0.01 67.558);
   --color-white: #fff;
   --spacing: 0.25rem;
   --container-xl: 36rem;
@@ -98,6 +102,8 @@
   --text-2xl--line-height: calc(2 / 1.5);
   --text-3xl: 1.875rem;
   --text-3xl--line-height: calc(2.25 / 1.875);
+  --text-4xl: 2.25rem;
+  --text-4xl--line-height: calc(2.5 / 2.25);
   --text-9xl: 8rem;
   --text-9xl--line-height: 1;
   --font-weight-normal: 400;
@@ -105,22 +111,14 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   --tracking-wider: 0.05em;
+  --leading-relaxed: 1.625;
   --radius-sm: 0.25rem;
   --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
   --default-transition-duration: 150ms;
   --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   --default-font-family: var(--font-sans);
-  --default-font-feature-settings: var(--font-sans--font-feature-settings);
-  --default-font-variation-settings: var(
-      --font-sans--font-variation-settings
-    );
   --default-mono-font-family: var(--font-mono);
-  --default-mono-font-feature-settings: var(
-      --font-mono--font-feature-settings
-    );
-  --default-mono-font-variation-settings: var(
-      --font-mono--font-variation-settings
-    );
 }
 @layer theme, base, components, utilities;
 @layer theme;
@@ -135,13 +133,10 @@
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
-    font-family: var( --default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" );
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
     font-feature-settings: var(--default-font-feature-settings, normal);
-    font-variation-settings: var( --default-font-variation-settings, normal );
+    font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
-  }
-  body {
-    line-height: inherit;
   }
   hr {
     height: 0;
@@ -165,9 +160,9 @@
     font-weight: bolder;
   }
   code, kbd, samp, pre {
-    font-family: var( --default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace );
-    font-feature-settings: var( --default-mono-font-feature-settings, normal );
-    font-variation-settings: var( --default-mono-font-variation-settings, normal );
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
     font-size: 1em;
   }
   small {
@@ -231,9 +226,13 @@
   }
   ::placeholder {
     opacity: 1;
-    color: currentColor;
-    @supports (color: color-mix(in lab, red, red)) {
-      color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
     }
   }
   textarea {
@@ -255,6 +254,9 @@
   ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
     padding-block: 0;
   }
+  ::-webkit-calendar-picker-indicator {
+    line-height: 1;
+  }
   :-moz-ui-invalid {
     box-shadow: none;
   }
@@ -271,6 +273,9 @@
 @layer utilities {
   .pointer-events-none {
     pointer-events: none;
+  }
+  .collapse {
+    visibility: collapse;
   }
   .invisible {
     visibility: hidden;
@@ -308,14 +313,14 @@
   .end {
     inset-inline-end: var(--spacing);
   }
+  .end-0 {
+    inset-inline-end: calc(var(--spacing) * 0);
+  }
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
   .right-0 {
     right: calc(var(--spacing) * 0);
-  }
-  .bottom-0 {
-    bottom: calc(var(--spacing) * 0);
   }
   .z-10 {
     z-index: 10;
@@ -424,6 +429,10 @@
   }
   .table {
     display: table;
+  }
+  .size-3\.5 {
+    width: calc(var(--spacing) * 3.5);
+    height: calc(var(--spacing) * 3.5);
   }
   .size-4 {
     width: calc(var(--spacing) * 4);
@@ -549,6 +558,9 @@
   .gap-4 {
     gap: calc(var(--spacing) * 4);
   }
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
+  }
   .gap-8 {
     gap: calc(var(--spacing) * 8);
   }
@@ -625,6 +637,9 @@
   .rounded-sm {
     border-radius: var(--radius-sm);
   }
+  .rounded-xl {
+    border-radius: var(--radius-xl);
+  }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
@@ -632,10 +647,6 @@
   .border-2 {
     border-style: var(--tw-border-style);
     border-width: 2px;
-  }
-  .border-e {
-    border-inline-end-style: var(--tw-border-style);
-    border-inline-end-width: 1px;
   }
   .border-t {
     border-top-style: var(--tw-border-style);
@@ -668,11 +679,17 @@
   .\!border-gray-600 {
     border-color: var(--color-gray-600) !important;
   }
-  .\!border-gray-700 {
-    border-color: var(--color-gray-700) !important;
+  .\!border-transparent {
+    border-color: transparent !important;
   }
   .\!border-yellow-800 {
     border-color: var(--color-yellow-800) !important;
+  }
+  .border-amber-800\/40 {
+    border-color: color-mix(in srgb, oklch(47.3% 0.137 46.201) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-amber-800) 40%, transparent);
+    }
   }
   .border-blue-100 {
     border-color: var(--color-blue-100);
@@ -866,9 +883,6 @@
   .bg-slate-900 {
     background-color: var(--color-slate-900);
   }
-  .bg-stone-50 {
-    background-color: var(--color-stone-50);
-  }
   .bg-stone-700 {
     background-color: var(--color-stone-700);
   }
@@ -926,8 +940,14 @@
   .p-2 {
     padding: calc(var(--spacing) * 2);
   }
+  .p-3 {
+    padding: calc(var(--spacing) * 3);
+  }
   .p-4 {
     padding: calc(var(--spacing) * 4);
+  }
+  .p-6 {
+    padding: calc(var(--spacing) * 6);
   }
   .p-8 {
     padding: calc(var(--spacing) * 8);
@@ -962,6 +982,9 @@
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
   }
+  .py-1\.5 {
+    padding-block: calc(var(--spacing) * 1.5);
+  }
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
   }
@@ -980,8 +1003,11 @@
   .ps-10 {
     padding-inline-start: calc(var(--spacing) * 10);
   }
-  .pe-4 {
-    padding-inline-end: calc(var(--spacing) * 4);
+  .pe-3 {
+    padding-inline-end: calc(var(--spacing) * 3);
+  }
+  .pe-9 {
+    padding-inline-end: calc(var(--spacing) * 9);
   }
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
@@ -991,6 +1017,9 @@
   }
   .pt-4 {
     padding-top: calc(var(--spacing) * 4);
+  }
+  .pt-6 {
+    padding-top: calc(var(--spacing) * 6);
   }
   .pt-12 {
     padding-top: calc(var(--spacing) * 12);
@@ -1003,9 +1032,6 @@
   }
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
-  }
-  .pb-10 {
-    padding-bottom: calc(var(--spacing) * 10);
   }
   .pl-2 {
     padding-left: calc(var(--spacing) * 2);
@@ -1038,6 +1064,10 @@
   .text-3xl {
     font-size: var(--text-3xl);
     line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-4xl {
+    font-size: var(--text-4xl);
+    line-height: var(--tw-leading, var(--text-4xl--line-height));
   }
   .text-9xl {
     font-size: var(--text-9xl);
@@ -1094,6 +1124,10 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
+  .tracking-wider {
+    --tw-tracking: var(--tracking-wider);
+    letter-spacing: var(--tracking-wider);
+  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -1105,6 +1139,21 @@
   }
   .\!text-gray-300 {
     color: var(--color-gray-300) !important;
+  }
+  .text-amber-200\/70 {
+    color: color-mix(in srgb, oklch(92.4% 0.12 95.746) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-amber-200) 70%, transparent);
+    }
+  }
+  .text-amber-300 {
+    color: var(--color-amber-300);
+  }
+  .text-amber-400 {
+    color: var(--color-amber-400);
+  }
+  .text-amber-500 {
+    color: var(--color-amber-500);
   }
   .text-amber-600 {
     color: var(--color-amber-600);
@@ -1214,8 +1263,14 @@
   .lowercase {
     text-transform: lowercase;
   }
+  .uppercase {
+    text-transform: uppercase;
+  }
   .italic {
     font-style: italic;
+  }
+  .no-underline {
+    text-decoration-line: none;
   }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -1248,6 +1303,10 @@
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
+  .backdrop-filter {
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
@@ -1258,13 +1317,10 @@
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
-  .content-\[\'▸\'\] {
-    --tw-content: '▸';
-    content: var(--tw-content);
-  }
-  .content-\[\'▾\'\] {
-    --tw-content: '▾';
-    content: var(--tw-content);
+  .transition-colors {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
   .placeholder\:text-gray-500 {
     &::placeholder {
@@ -1280,12 +1336,6 @@
   .before\:content-\[\'\*\'\] {
     &::before {
       --tw-content: '*';
-      content: var(--tw-content);
-    }
-  }
-  .after\:content-\[\'⋮\'\] {
-    &::after {
-      --tw-content: '⋮';
       content: var(--tw-content);
     }
   }
@@ -1314,6 +1364,16 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-700) !important;
+      }
+    }
+  }
+  .hover\:\!bg-gray-800\/60 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, oklch(27.8% 0.033 256.848) 60%, transparent) !important;
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-gray-800) 60%, transparent) !important;
+        }
       }
     }
   }
@@ -1373,6 +1433,20 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-white) !important;
+      }
+    }
+  }
+  .hover\:text-amber-300 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-amber-300);
+      }
+    }
+  }
+  .hover\:text-gray-200 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-200);
       }
     }
   }
@@ -1441,6 +1515,11 @@
       display: block;
     }
   }
+  .md\:hidden {
+    @media (width >= 48rem) {
+      display: none;
+    }
+  }
   .md\:h-1\/2 {
     @media (width >= 48rem) {
       height: calc(1 / 2 * 100%);
@@ -1489,22 +1568,6 @@
   .md\:justify-start {
     @media (width >= 48rem) {
       justify-content: flex-start;
-    }
-  }
-  .md\:pl-72 {
-    @media (width >= 48rem) {
-      padding-left: calc(var(--spacing) * 72);
-    }
-  }
-  .lg\:end-auto {
-    @media (width >= 64rem) {
-      inset-inline-end: auto;
-    }
-  }
-  .lg\:translate-x-0 {
-    @media (width >= 64rem) {
-      --tw-translate-x: calc(var(--spacing) * 0);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
     }
   }
 }
@@ -1723,7 +1786,10 @@
   }
   table tr {
     &:nth-child(odd) {
-      background-color: var(--color-gray-800);
+      background-color: color-mix(in srgb, oklch(21% 0.034 264.665) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-gray-900) 40%, transparent);
+      }
     }
   }
   table td {
@@ -1734,14 +1800,14 @@
     border: 1px solid #4b5563;
   }
   table thead th {
-    background-color: var(--color-gray-900);
+    background-color: var(--color-gray-950);
     padding: calc(var(--spacing) * 2);
     text-align: left;
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
-    color: var(--color-slate-200);
+    color: var(--color-slate-300);
     border: 1px solid #4b5563;
   }
   table + p {
@@ -1773,12 +1839,7 @@
     letter-spacing: var(--tracking-wider);
   }
   .wrapper {
-    @media (width >= 48rem) {
-      padding-left: calc(var(--spacing) * 72);
-    }
-    @media (width >= 64rem) {
-      padding-right: calc(var(--spacing) * 60);
-    }
+    padding-inline: calc(var(--spacing) * 6);
   }
   .content {
     margin-inline: auto;
@@ -1863,22 +1924,28 @@
     display: none;
     height: 100%;
     width: calc(var(--spacing) * 72);
-    border-inline-end-style: var(--tw-border-style);
-    border-inline-end-width: 1px;
-    border-color: var(--color-gray-700);
-    background-color: var(--color-gray-900);
     @media (width >= 48rem) {
       display: block;
     }
-    @media (width >= 64rem) {
-      inset-inline-end: auto;
+    background: #0b0f17;
+    box-shadow: 4px 0 24px rgba(0,0,0,0.5);
+  }
+  .sidebar > div {
+    padding-top: var(--top-bar-height);
+  }
+  .sidebar-logo-wrap {
+    padding-top: 0.5rem;
+  }
+  @media (min-width: 48rem) {
+    .sidebar {
+      background: radial-gradient(ellipse at 100% 50%, #0e131b 10%, transparent 70%);
+      box-shadow: none;
     }
-    @media (width >= 64rem) {
-      bottom: calc(var(--spacing) * 0);
+    .sidebar > div {
+      padding-top: 0;
     }
-    @media (width >= 64rem) {
-      --tw-translate-x: calc(var(--spacing) * 0);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
+    .sidebar-logo-wrap {
+      padding-top: 1rem;
     }
   }
   .sidebar .sidebar-content {
@@ -1893,26 +1960,6 @@
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
   }
-  .sidebar a.has-children.collapsed {
-    &::after {
-      content: var(--tw-content);
-      padding-right: calc(var(--spacing) * 2);
-    }
-    &::after {
-      --tw-content: '⋮';
-      content: var(--tw-content);
-    }
-  }
-  .sidebar a.has-children.expanded {
-    &::after {
-      content: var(--tw-content);
-      padding-right: calc(var(--spacing) * 2);
-    }
-    &::after {
-      --tw-content: '⋮';
-      content: var(--tw-content);
-    }
-  }
   .sidebar .btn {
     overflow: hidden;
   }
@@ -1924,17 +1971,20 @@
     padding-bottom: 0.2rem;
   }
   .sidebar .btn.btn-transparent {
-    border-color: var(--color-gray-700) !important;
+    border-color: transparent !important;
     background-color: transparent !important;
     color: var(--color-gray-300) !important;
     &:hover {
       @media (hover: hover) {
-        border-color: var(--color-gray-600) !important;
+        border-color: transparent !important;
       }
     }
     &:hover {
       @media (hover: hover) {
-        background-color: var(--color-gray-700) !important;
+        background-color: color-mix(in srgb, oklch(27.8% 0.033 256.848) 60%, transparent) !important;
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-gray-800) 60%, transparent) !important;
+        }
       }
     }
     &:hover {
@@ -1942,9 +1992,14 @@
         color: var(--color-gray-100) !important;
       }
     }
+    transition: background-color 0.15s, color 0.15s;
   }
   .sidebar .btn.btn-primary {
+    background-color: transparent !important;
     color: var(--color-white);
+    border-left: 2px solid var(--color-primary);
+    border-radius: 0;
+    transition: background-color 0.15s, color 0.15s;
   }
   .sidebar .btn .icon {
     border-color: var(--color-gray-700) !important;
@@ -1959,6 +2014,7 @@
       content: var(--tw-content);
       color: var(--color-white);
     }
+    border-left: 2px solid var(--color-primary);
   }
   .sidebar .btn.level-1:not(.btn-primary) {
     &:hover {
@@ -1979,6 +2035,9 @@
     --tw-border-style: none;
     border-style: none;
   }
+  .sidebar .btn.level-2.btn-primary {
+    border-left: 2px solid var(--color-primary);
+  }
   .sidebar .btn.level-2 .text {
     font-size: 0.9rem;
   }
@@ -1987,6 +2046,9 @@
     border-right-width: 0px;
     --tw-border-style: none;
     border-style: none;
+  }
+  .sidebar .btn.level-3.btn-primary {
+    border-left: 2px solid var(--color-primary);
   }
   .sidebar .btn.level-3 .text {
     font-size: 0.8rem;
@@ -2033,37 +2095,59 @@
     color: #6b7280;
   }
   .sidebar li.level-1 {
-    border-left: 1px solid #374151;
+    border-left: 1px solid rgba(255,255,255,0.04);
   }
   .sidebar li.level-2 {
-    border-left: 1px solid #374151;
+    border-left: 1px solid rgba(255,255,255,0.06);
   }
   .sidebar li.level-3 {
-    border-left: 1px solid #4b5563;
+    border-left: 1px solid rgba(255,255,255,0.06);
   }
   .sidebar li.level-4 {
-    border-left: 1px solid #4b5563;
+    border-left: 1px solid rgba(255,255,255,0.04);
   }
   .sidebar li.level-5 {
-    border-left: 1px solid #374151;
+    border-left: 1px solid rgba(255,255,255,0.03);
   }
-  .sidebar a.has-children.collapsed::after {
-    margin-left: calc(var(--spacing) * 1);
+  .sidebar .toggle-arrow {
+    cursor: pointer;
+    border-radius: 0.25rem;
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2);
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
     color: var(--color-gray-500);
-    --tw-content: '▸';
-    content: var(--tw-content);
+    font-size: 0.75rem;
+    margin-left: auto;
+    transition: transform 0.2s ease, background-color 0.15s, color 0.15s;
   }
-  .sidebar a.has-children.expanded::after {
-    margin-left: calc(var(--spacing) * 1);
-    color: var(--color-gray-500);
-    --tw-content: '▾';
-    content: var(--tw-content);
+  .sidebar .toggle-arrow:hover {
+    background-color: var(--color-gray-700);
+    color: var(--color-gray-100);
+  }
+  .sidebar .toggle-arrow.is-open {
+    transform: rotate(90deg);
+  }
+  .sidebar li.search-dimmed {
+    opacity: 0.25;
+    transition: opacity 0.15s;
+  }
+  .sidebar li.search-match {
+    opacity: 1;
+  }
+  .sidebar li.search-match > a .text {
+    color: var(--color-primary) !important;
+    font-weight: bold;
   }
   .sidebar .collapsed + * {
-    display: none;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.4s ease-out;
   }
   .sidebar .expanded + * {
-    display: block;
+    max-height: 200rem;
+    overflow: hidden;
+    transition: max-height 0.5s ease-in;
   }
   .sidebar .is-disabled {
     cursor: not-allowed;
@@ -2178,68 +2262,213 @@
     display: none;
     height: 100%;
     width: calc(var(--spacing) * 60);
-    background-color: var(--color-gray-900);
     padding: calc(var(--spacing) * 2);
     word-break: break-all;
     @media (width >= 64rem) {
       display: block;
     }
+    background: radial-gradient(ellipse at 0% 50%, #0e131b 10%, transparent 70%);
   }
-  aside.on-this-page .btn {
+  aside.on-this-page > div:nth-child(1) {
+    padding: calc(var(--spacing) * 3);
+    padding-top: calc(var(--spacing) * 6);
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
-  }
-  aside.on-this-page > div:nth-child(1) {
-    display: flex;
-    align-items: center;
-    padding: calc(var(--spacing) * 1);
-    font-size: var(--text-sm);
-    line-height: var(--tw-leading, var(--text-sm--line-height));
-    --tw-font-weight: var(--font-weight-semibold);
-    font-weight: var(--font-weight-semibold);
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    --tw-tracking: var(--tracking-wider);
+    letter-spacing: var(--tracking-wider);
+    color: var(--color-gray-500);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
   }
   aside.on-this-page > div:nth-child(2) {
-    padding: calc(var(--spacing) * 2);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 1);
   }
-  aside.on-this-page > div:nth-child(1) {
-    color: var(--color-slate-200);
-  }
-  aside.on-this-page > div:nth-child(2) .heading-level-1 {
-    padding-top: calc(var(--spacing) * 2);
-    padding-bottom: calc(var(--spacing) * 2);
+  aside.on-this-page > div:nth-child(2) a {
+    display: block;
+    border-radius: 0.25rem;
+    padding-inline: calc(var(--spacing) * 2);
+    padding-block: calc(var(--spacing) * 1.5);
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
-    --tw-font-weight: var(--font-weight-normal);
-    font-weight: var(--font-weight-normal);
-    color: var(--color-slate-200);
+    color: var(--color-gray-400);
+    text-decoration-line: none;
+    transition: color 0.15s, background-color 0.15s;
+    border-left: 2px solid transparent;
+  }
+  aside.on-this-page > div:nth-child(2) a:hover {
+    background-color: color-mix(in srgb, oklch(27.8% 0.033 256.848) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-gray-800) 40%, transparent);
+    }
+    color: var(--color-gray-100);
+    border-left-color: var(--color-primary);
   }
   aside.on-this-page > div:nth-child(2) .heading-level-1 a {
-    color: var(--color-slate-200) !important;
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    color: var(--color-gray-300);
   }
   aside.on-this-page > div:nth-child(2) .heading-level-2 a {
     margin-left: calc(var(--spacing) * 2);
-    padding: calc(var(--spacing) * 0);
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
-    color: var(--color-gray-300) !important;
+    color: var(--color-gray-500);
   }
-  aside.on-this-page .btn.btn-transparent {
-    border-color: var(--color-gray-700) !important;
-    background-color: transparent !important;
-    color: var(--color-gray-300) !important;
+  :root {
+    --top-bar-height: 2.25rem;
+  }
+  .top-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 70;
+    height: var(--top-bar-height);
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1.5rem;
+    padding-inline: 1.5rem;
+    padding-right: 3rem;
+    background: rgba(9, 11, 17, 0.3);
+    backdrop-filter: blur(6px);
+  }
+  .top-bar-link {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: #6b7280;
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .top-bar-link:hover {
+    color: #d1d5db;
+    text-decoration: none;
+  }
+  .top-bar-hubleto {
+    color: var(--color-primary);
+  }
+  .top-bar-hubleto:hover {
+    color: var(--color-secondary);
+  }
+  .top-bar-link i {
+    font-size: 1.25rem;
+  }
+  .top-bar-desktop {
+    display: none;
+    @media (width >= 48rem) {
+      display: flex;
+    }
+  }
+  .top-bar-burger {
+    cursor: pointer;
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 1);
+    color: var(--color-gray-300);
     &:hover {
       @media (hover: hover) {
-        border-color: var(--color-gray-600) !important;
+        color: var(--color-white);
+      }
+    }
+    @media (width >= 48rem) {
+      display: none;
+    }
+    background: transparent;
+    border: none;
+    font-size: 1.1rem;
+    margin-right: auto;
+  }
+  @media (min-width: 48rem) {
+    body {
+      display: flex;
+      align-items: flex-start;
+      max-width: 97rem;
+      margin-inline: auto;
+      min-height: 100vh;
+      padding-top: var(--top-bar-height);
+    }
+    .sidebar {
+      position: sticky;
+      top: var(--top-bar-height);
+      height: calc(100vh - var(--top-bar-height));
+      flex-shrink: 0;
+      inset-inline-start: 0;
+    }
+    .wrapper {
+      flex: 1 1 0%;
+      min-width: 0;
+    }
+  }
+  @media (min-width: 64rem) {
+    aside.on-this-page {
+      position: sticky;
+      top: var(--top-bar-height);
+      right: auto;
+      height: calc(100vh - var(--top-bar-height));
+      flex-shrink: 0;
+    }
+  }
+  .wip-banner {
+    margin-top: calc(var(--spacing) * 8);
+    display: flex;
+    align-items: flex-start;
+    gap: calc(var(--spacing) * 5);
+    border-radius: var(--radius-xl);
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+    border-color: color-mix(in srgb, oklch(47.3% 0.137 46.201) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-amber-800) 40%, transparent);
+    }
+    background-color: color-mix(in srgb, oklch(27.9% 0.077 45.635) 25%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-amber-950) 25%, transparent);
+    }
+    padding: calc(var(--spacing) * 6);
+  }
+  .wip-banner .wip-banner-icon {
+    flex-shrink: 0;
+    padding-top: calc(var(--spacing) * 1);
+    font-size: var(--text-4xl);
+    line-height: var(--tw-leading, var(--text-4xl--line-height));
+    color: var(--color-amber-500);
+  }
+  .wip-banner .wip-banner-title {
+    margin-bottom: calc(var(--spacing) * 1);
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-amber-300);
+  }
+  .wip-banner p {
+    padding-top: calc(var(--spacing) * 0);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-leading: var(--leading-relaxed);
+    line-height: var(--leading-relaxed);
+    color: color-mix(in srgb, oklch(92.4% 0.12 95.746) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-amber-200) 70%, transparent);
+    }
+  }
+  .wip-banner a {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    color: var(--color-amber-400);
+    text-decoration-line: none;
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-amber-300);
       }
     }
     &:hover {
       @media (hover: hover) {
-        background-color: var(--color-gray-700) !important;
-      }
-    }
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-gray-100) !important;
+        text-decoration-line: underline;
       }
     }
   }
@@ -3457,6 +3686,10 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-shadow {
   syntax: "*";
   inherits: false;
@@ -3580,28 +3813,45 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-backdrop-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-content {
   syntax: "*";
-  inherits: false;
   initial-value: "";
-}
-@property --tw-translate-x {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-@property --tw-translate-y {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-@property --tw-translate-z {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-@property --tw-tracking {
-  syntax: "*";
   inherits: false;
 }
 @layer properties {
@@ -3618,6 +3868,7 @@
       --tw-divide-y-reverse: 0;
       --tw-leading: initial;
       --tw-font-weight: initial;
+      --tw-tracking: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;
@@ -3646,11 +3897,16 @@
       --tw-drop-shadow-color: initial;
       --tw-drop-shadow-alpha: 100%;
       --tw-drop-shadow-size: initial;
+      --tw-backdrop-blur: initial;
+      --tw-backdrop-brightness: initial;
+      --tw-backdrop-contrast: initial;
+      --tw-backdrop-grayscale: initial;
+      --tw-backdrop-hue-rotate: initial;
+      --tw-backdrop-invert: initial;
+      --tw-backdrop-opacity: initial;
+      --tw-backdrop-saturate: initial;
+      --tw-backdrop-sepia: initial;
       --tw-content: "";
-      --tw-translate-x: 0;
-      --tw-translate-y: 0;
-      --tw-translate-z: 0;
-      --tw-tracking: initial;
     }
   }
 }

--- a/v0/template/assets/css/theme.twcss
+++ b/v0/template/assets/css/theme.twcss
@@ -45,15 +45,15 @@
   pre + h6, table + h6 { @apply italic text-sm text-gray-500; }
 
   table { @apply border border-gray-500 !mt-4; border-collapse: collapse; }
-  table tr { @apply odd:bg-gray-800; }
+  table tr { @apply odd:bg-gray-900/40; }
   table td { @apply p-1.5 text-sm text-slate-300; border: 1px solid #4b5563; }
-  table thead th { @apply font-bold text-left p-2 bg-gray-900 text-sm text-slate-200; border: 1px solid #4b5563; }
+  table thead th { @apply font-bold text-left p-2 bg-gray-950 text-sm text-slate-300; border: 1px solid #4b5563; }
   table + p { @apply text-slate-500 mb-4 text-xs pt-0 pb-4; }
 
   blockquote { @apply m-8 p-4 bg-primary/5 border border-primary shadow max-w-xl relative; }
   blockquote * { @apply p-0 tracking-wider; }
 
-  .wrapper { @apply md:pl-72 lg:pr-60; }
+  .wrapper { @apply px-6; }
   .content { @apply p-8 max-w-5xl mx-auto space-y-1; }
   .content img { @apply mx-auto mt-4 border border-gray-700 max-w-xl shadow-sm rounded-sm bg-gray-800 text-xs; }
   .content img + h6 { @apply italic text-sm text-gray-500 mx-auto text-center; }
@@ -64,29 +64,36 @@
   .header .menu-button { @apply block md:hidden; }
   .header a { @apply text-white; }
 
-  .sidebar { @apply w-72 h-full hidden fixed inset-y-0 start-0 z-[60] bg-gray-900 border-e border-gray-700 md:block lg:translate-x-0 lg:end-auto lg:bottom-0; }
+  .sidebar { @apply w-72 h-full hidden fixed inset-y-0 start-0 z-[60] md:block; background: #0b0f17; box-shadow: 4px 0 24px rgba(0,0,0,0.5); }
+  .sidebar > div { padding-top: var(--top-bar-height); }
+  .sidebar-logo-wrap { padding-top: 0.5rem; }
+  @media (min-width: 48rem) {
+    .sidebar { background: radial-gradient(ellipse at 100% 50%, #0e131b 10%, transparent 70%); box-shadow: none; }
+    .sidebar > div { padding-top: 0; }
+    .sidebar-logo-wrap { padding-top: 1rem; }
+  }
   .sidebar .sidebar-content { @apply h-full overflow-y-auto; }
   .sidebar .logo { @apply w-1/2 m-auto; }
 
   .sidebar a.expanded:not(.btn-primary) > .text { @apply font-bold; }
-  .sidebar a.has-children.collapsed { @apply after:content-['⋮'] after:pr-2; }
-  .sidebar a.has-children.expanded { @apply after:content-['⋮'] after:pr-2; }
   .sidebar .btn { @apply overflow-hidden; }
   .sidebar .btn .text { white-space: normal !important; word-break: break-word !important;line-height: 1.3;padding-top: 0.2rem;padding-bottom: 0.2rem;}
 
-  .sidebar .btn.btn-transparent { @apply !text-gray-300 !bg-transparent !border-gray-700 hover:!bg-gray-700 hover:!text-gray-100 hover:!border-gray-600; }
-  .sidebar .btn.btn-primary { @apply text-white; }
+  .sidebar .btn.btn-transparent { @apply !text-gray-300 !bg-transparent !border-transparent hover:!bg-gray-800/60 hover:!text-gray-100 hover:!border-transparent; transition: background-color 0.15s, color 0.15s; }
+  .sidebar .btn.btn-primary { @apply !bg-transparent text-white; border-left: 2px solid var(--color-primary); border-radius: 0; transition: background-color 0.15s, color 0.15s; }
   .sidebar .btn .icon { @apply !border-gray-700; }
   .sidebar .btn .text { @apply !border-gray-700; }
 
-  .sidebar .btn.level-1.btn-primary { @apply border-none before:text-white; }
+  .sidebar .btn.level-1.btn-primary { @apply border-none before:text-white; border-left: 2px solid var(--color-primary); }
   .sidebar .btn.level-1:not(.btn-primary) { @apply hover:bg-gray-800 hover:text-gray-100; }
   .sidebar .btn.level-1 .text { font-size: 1rem; }
 
   .sidebar .btn.level-2 { @apply border-none; }
+  .sidebar .btn.level-2.btn-primary { border-left: 2px solid var(--color-primary); }
   .sidebar .btn.level-2 .text {font-size: 0.9rem; }
 
   .sidebar .btn.level-3 { @apply border-none border-r-0; }
+  .sidebar .btn.level-3.btn-primary { border-left: 2px solid var(--color-primary); }
   .sidebar .btn.level-3 .text {font-size: 0.8rem; }
 
   :root { --sidebar-indent-step: 0.4rem; }
@@ -102,17 +109,26 @@
   .sidebar li.level-4 > a { font-size: 0.75rem; color: #9ca3af; }
   .sidebar li.level-5 > a { font-size: 0.7rem; color: #6b7280; }
 
-  .sidebar li.level-1 { border-left: 1px solid #374151; }
-  .sidebar li.level-2 { border-left: 1px solid #374151; }
-  .sidebar li.level-3 { border-left: 1px solid #4b5563; }
-  .sidebar li.level-4 { border-left: 1px solid #4b5563; }
-  .sidebar li.level-5 { border-left: 1px solid #374151; }
+  .sidebar li.level-1 { border-left: 1px solid rgba(255,255,255,0.04); }
+  .sidebar li.level-2 { border-left: 1px solid rgba(255,255,255,0.06); }
+  .sidebar li.level-3 { border-left: 1px solid rgba(255,255,255,0.06); }
+  .sidebar li.level-4 { border-left: 1px solid rgba(255,255,255,0.04); }
+  .sidebar li.level-5 { border-left: 1px solid rgba(255,255,255,0.03); }
 
-  .sidebar a.has-children.collapsed::after { @apply content-['▸'] text-gray-500 ml-1; }
-  .sidebar a.has-children.expanded::after { @apply content-['▾'] text-gray-500 ml-1; }
+  .sidebar .toggle-arrow {
+    @apply text-gray-500 px-3 py-2 cursor-pointer rounded font-bold;
+    font-size: 0.75rem;
+    margin-left: auto;
+    transition: transform 0.2s ease, background-color 0.15s, color 0.15s;
+  }
+  .sidebar .toggle-arrow:hover { @apply text-gray-100 bg-gray-700; }
+  .sidebar .toggle-arrow.is-open { transform: rotate(90deg); }
 
-  .sidebar .collapsed + * { @apply hidden; }
-  .sidebar .expanded + * { @apply block; }
+  .sidebar li.search-dimmed { opacity: 0.25; transition: opacity 0.15s; }
+  .sidebar li.search-match { opacity: 1; }
+  .sidebar li.search-match > a .text { color: var(--color-primary) !important; font-weight: bold; }
+  .sidebar .collapsed + * { max-height: 0; overflow: hidden; transition: max-height 0.4s ease-out; }
+  .sidebar .expanded + * { max-height: 200rem; overflow: hidden; transition: max-height 0.5s ease-in; }
   .sidebar .is-disabled {@apply text-gray-600 cursor-not-allowed opacity-70;}
   .sidebar .is-disabled:hover {@apply bg-transparent text-gray-600 no-underline;}
   .sidebar .is-disabled .text::before {content: "WIP";@apply text-[9px] font-semibold bg-amber-100 text-amber-600 mr-2 px-1.5 py-0.5 rounded-full border border-amber-300;white-space: nowrap !important;}
@@ -135,14 +151,98 @@
 
   .btn.btn-white { @apply !text-gray-200 !bg-gray-700 !border-gray-600 hover:!bg-gray-600 hover:!text-gray-100; }
 
-  aside.on-this-page { @apply fixed top-0 right-0 h-full w-60 break-all bg-gray-900 z-20 p-2 hidden lg:block; }
-  aside.on-this-page .btn { @apply text-xs; }
-  aside.on-this-page > div:nth-child(1) { @apply text-sm p-1 flex items-center font-semibold; }
-  aside.on-this-page > div:nth-child(2) { @apply p-2; }
-  aside.on-this-page > div:nth-child(1) { @apply text-slate-200; }
-  aside.on-this-page > div:nth-child(2) .heading-level-1 { @apply pt-2 pb-2 text-sm font-normal text-slate-200; }
-  aside.on-this-page > div:nth-child(2) .heading-level-1 a { @apply !text-slate-200; }
-  aside.on-this-page > div:nth-child(2) .heading-level-2 a { @apply text-xs ml-2 p-0 !text-gray-300; }
-  aside.on-this-page .btn.btn-transparent { @apply !text-gray-300 !bg-transparent !border-gray-700 hover:!bg-gray-700 hover:!text-gray-100 hover:!border-gray-600; }
+  aside.on-this-page { @apply fixed top-0 right-0 h-full w-60 break-all z-20 p-2 hidden lg:block; background: radial-gradient(ellipse at 0% 50%, #0e131b 10%, transparent 70%); }
+  aside.on-this-page > div:nth-child(1) { @apply text-xs uppercase tracking-wider p-3 pt-6 text-gray-500 font-medium; letter-spacing: 0.12em; }
+  aside.on-this-page > div:nth-child(2) { @apply px-3 py-1; }
+  aside.on-this-page > div:nth-child(2) a {
+    @apply block text-sm text-gray-400 py-1.5 px-2 rounded no-underline;
+    transition: color 0.15s, background-color 0.15s;
+    border-left: 2px solid transparent;
+  }
+  aside.on-this-page > div:nth-child(2) a:hover {
+    @apply text-gray-100 bg-gray-800/40;
+    border-left-color: var(--color-primary);
+  }
+  aside.on-this-page > div:nth-child(2) .heading-level-1 a { @apply text-sm text-gray-300; }
+  aside.on-this-page > div:nth-child(2) .heading-level-2 a { @apply text-xs text-gray-500 ml-2; }
+
+  /* Top bar */
+  :root { --top-bar-height: 2.25rem; }
+  .top-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 70;
+    height: var(--top-bar-height);
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1.5rem;
+    padding-inline: 1.5rem;
+    padding-right: 3rem;
+    background: rgba(9, 11, 17, 0.3);
+    backdrop-filter: blur(6px);
+  }
+  .top-bar-link {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: #6b7280;
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .top-bar-link:hover { color: #d1d5db; text-decoration: none; }
+  .top-bar-hubleto { color: var(--color-primary); }
+  .top-bar-hubleto:hover { color: var(--color-secondary); }
+  .top-bar-link i { font-size: 1.25rem; }
+  .top-bar-desktop { @apply hidden md:flex; }
+  .top-bar-burger {
+    @apply md:hidden text-gray-300 hover:text-white px-3 py-1 cursor-pointer;
+    background: transparent;
+    border: none;
+    font-size: 1.1rem;
+    margin-right: auto;
+  }
+
+  /* Desktop layout: flex row with centered max-width so sidebars hug the content column */
+  @media (min-width: 48rem) {
+    body {
+      display: flex;
+      align-items: flex-start;
+      max-width: 97rem;
+      margin-inline: auto;
+      min-height: 100vh;
+      padding-top: var(--top-bar-height);
+    }
+    .sidebar {
+      position: sticky;
+      top: var(--top-bar-height);
+      height: calc(100vh - var(--top-bar-height));
+      flex-shrink: 0;
+      inset-inline-start: 0;
+    }
+    .wrapper {
+      flex: 1 1 0%;
+      min-width: 0;
+    }
+  }
+  @media (min-width: 64rem) {
+    aside.on-this-page {
+      position: sticky;
+      top: var(--top-bar-height);
+      right: auto;
+      height: calc(100vh - var(--top-bar-height));
+      flex-shrink: 0;
+    }
+  }
+
+  /* Work in progress banner */
+  .wip-banner { @apply flex gap-5 items-start mt-8 p-6 rounded-xl border border-amber-800/40 bg-amber-950/25; }
+  .wip-banner .wip-banner-icon { @apply text-4xl text-amber-500 shrink-0 pt-1; }
+  .wip-banner .wip-banner-title { @apply text-base font-semibold text-amber-300 mb-1; }
+  .wip-banner p { @apply text-amber-200/70 text-sm pt-0 leading-relaxed; }
+  .wip-banner a { @apply text-amber-400 text-sm hover:text-amber-300 no-underline hover:underline; }
 
 }

--- a/v0/template/elements/footer.twig
+++ b/v0/template/elements/footer.twig
@@ -1,4 +1,1 @@
-<div class="fixed bottom-0 z-[60] w-full bg-gray-900 p-2 text-xs text-gray-400 border-t border-gray-700">
-  <a href="https://www.hubleto.eu" class="text-xs" target="_blank">www.hubleto.eu</a> |
-  Found a bug or missing something? Report an <a href="https://github.com/hubleto/erp/issues" class="text-xs" target="_blank">issue via GitHub</a>.
-</div>
+{# footer moved to sidebar #}

--- a/v0/template/elements/on-this-page.twig
+++ b/v0/template/elements/on-this-page.twig
@@ -1,10 +1,10 @@
-{% if onThisPage|length > 0 %}
-  <aside class="on-this-page">
+<aside class="on-this-page">
+  {% if onThisPage|length > 0 %}
     <div><div>On this page</div></div>
     <div>
       {% for h2, h3list in onThisPage %}
-        <a href="#{{ h2 }}" class="btn btn-transparent w-full mb-2"><span class="text">{{ h2 }}</span></a>
+        <a href="#{{ h2 }}"><span class="text">{{ h2 }}</span></a>
       {% endfor %}
     </div>
-  </aside>
-{% endif %}
+  {% endif %}
+</aside>

--- a/v0/template/elements/sidebar.twig
+++ b/v0/template/elements/sidebar.twig
@@ -8,6 +8,7 @@
     <li id="{{ itemIdPrefix }}_{{ itemCounter }}" class="level-{{ level }}">
       {% if item.children is iterable %}
         <a href="{% if not isWip %}{{ env.guideRootUrl }}/{{ item.page ?? '' }}{% else %}{{ env.guideRootUrl }}/{{ item.page }}{% endif %}"
+          data-page="{{ item.page }}"
           class="
             btn
             {% if breadcrumbs|last == item.page %} btn-primary {% else %} btn-transparent {% endif %}
@@ -22,6 +23,9 @@
           {% if level == 0 %} <span class="icon"><i class="{{ item.icon }}"></i></span> {% endif %}
           <span class="text grow {% if level == 0 %} font-bold {% endif %}">
             {{ pageTitle }}
+          </span>
+          <span class="toggle-arrow {% if item.page in breadcrumbs %}is-open{% endif %}" onclick="event.preventDefault(); event.stopPropagation(); toggleTree(this.parentElement);">
+            <i class="fas fa-chevron-right"></i>
           </span>
         </a>
         <div
@@ -62,15 +66,15 @@
 <!-- Sidebar -->
 <div class="sidebar" role="dialog" tabindex="-1" aria-label="Sidebar">
 
-  <div class="relative flex flex-col h-full max-h-full pb-10">
-    <div class="m-auto mt-2 mb-2">
+  <div class="relative flex flex-col h-full max-h-full">
+    <div class="mx-auto mb-2 sidebar-logo-wrap">
       <a href="{{ guideRootUrl }}"><img class="logo" src="{{ templateRootUrl }}/assets/images/logo-hubleto-text-vertical.png"/></a>
     </div>
     <div class="m-auto px-6 pt-0 pb-4 text-center">
       <div class="my-2">Developer's guide</div>
     </div>
     <div class="px-3 pb-2">
-      <form action="{{ env.guideRootUrl }}/{{ searchPage }}" method="get">
+      <form action="{{ env.guideRootUrl }}/{{ searchPage }}" method="get" onsubmit="if(!this.q.value.trim())return false;">
         <div class="relative">
           <div class="absolute inset-y-0 start-0 flex items-center pointer-events-none z-20 ps-3.5">
             <svg class="shrink-0 size-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -81,10 +85,15 @@
           <input
             type="text"
             name="q"
-            class="py-2 ps-10 pe-4 block w-full bg-gray-800 border-gray-700 text-slate-300 placeholder:text-gray-500 rounded-lg text-sm focus:outline-none focus:border-blue-500 focus:ring-blue-500"
-            placeholder="Search..."
+            class="py-2 ps-10 pe-9 block w-full bg-gray-800 border-gray-700 text-slate-300 placeholder:text-gray-500 rounded-lg text-sm focus:outline-none focus:border-blue-500 focus:ring-blue-500"
+            placeholder="Press Enter for full search"
             value="{{ data.query ?? '' }}"
           >
+          <button type="button" class="search-clear absolute inset-y-0 end-0 flex items-center pe-3 z-20" onclick="clearSearch()" style="display:none;">
+            <svg class="shrink-0 size-3.5 text-gray-400 hover:text-gray-200 transition-colors" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+            </svg>
+          </button>
         </div>
       </form>
     </div>
@@ -117,6 +126,148 @@
         break;
     }
   }
+
+  function getSidebarState() {
+    try { return JSON.parse(localStorage.getItem('sidebarState') || '{}'); } catch(e) { return {}; }
+  }
+
+  function saveSidebarState() {
+    var state = {};
+    document.querySelectorAll('.sidebar .has-children[data-page]').forEach(function(el) {
+      state[el.getAttribute('data-page')] = el.classList.contains('expanded');
+    });
+    localStorage.setItem('sidebarState', JSON.stringify(state));
+  }
+
+  function toggleTree(el) {
+    var arrow = el.querySelector('.toggle-arrow');
+    if (el.classList.contains('expanded')) {
+      el.classList.remove('expanded');
+      el.classList.add('collapsed');
+      if (arrow) arrow.classList.remove('is-open');
+    } else {
+      el.classList.remove('collapsed');
+      el.classList.add('expanded');
+      if (arrow) arrow.classList.add('is-open');
+    }
+    saveSidebarState();
+  }
+
+  // Restore saved open states on page load
+  (function() {
+    var saved = getSidebarState();
+    document.querySelectorAll('.sidebar .has-children[data-page]').forEach(function(el) {
+      var page = el.getAttribute('data-page');
+      if (saved[page] === true && el.classList.contains('collapsed')) {
+        el.classList.remove('collapsed');
+        el.classList.add('expanded');
+        var arrow = el.querySelector('.toggle-arrow');
+        if (arrow) arrow.classList.add('is-open');
+      }
+    });
+  })();
+
+  function clearSearch() {
+    var input = document.querySelector('.sidebar input[name="q"]');
+    if (input) {
+      input.value = '';
+      input.dispatchEvent(new Event('input'));
+      input.focus();
+    }
+  }
+
+  // Live search — dim non-matches, highlight matching text
+  (function() {
+    var input = document.querySelector('.sidebar input[name="q"]');
+    if (!input) return;
+
+    var clearBtn = document.querySelector('.search-clear');
+    var allItems = document.querySelectorAll('.sidebar-content nav li');
+
+    // Capture initial server-rendered expanded state + original text per item
+    var initialExpanded = {};
+    document.querySelectorAll('.sidebar .has-children[data-page]').forEach(function(el) {
+      initialExpanded[el.getAttribute('data-page')] = el.classList.contains('expanded');
+    });
+    allItems.forEach(function(li) {
+      var textEl = li.querySelector(':scope > a .text');
+      if (textEl) li._origText = textEl.textContent.trim();
+    });
+
+    function resetFilter() {
+      allItems.forEach(function(li) {
+        li.classList.remove('search-dimmed', 'search-match');
+      });
+      // Restore expand/collapse: server-rendered breadcrumb state OR saved localStorage
+      var saved = getSidebarState();
+      document.querySelectorAll('.sidebar .has-children[data-page]').forEach(function(el) {
+        var page = el.getAttribute('data-page');
+        var shouldExpand = saved[page] !== undefined ? saved[page] : initialExpanded[page];
+        var arrow = el.querySelector('.toggle-arrow');
+        if (shouldExpand) {
+          el.classList.remove('collapsed');
+          el.classList.add('expanded');
+          if (arrow) arrow.classList.add('is-open');
+        } else {
+          el.classList.remove('expanded');
+          el.classList.add('collapsed');
+          if (arrow) arrow.classList.remove('is-open');
+        }
+      });
+    }
+
+
+    function expandParentChain(li) {
+      var node = li.parentElement;
+      while (node) {
+        if (node.tagName === 'LI') {
+          node.classList.remove('search-dimmed');
+          var link = node.querySelector(':scope > a.has-children');
+          if (link) {
+            link.classList.remove('collapsed');
+            link.classList.add('expanded');
+            var arrow = link.querySelector('.toggle-arrow');
+            if (arrow) arrow.classList.add('is-open');
+          }
+        }
+        node = node.parentElement;
+        if (node && node.classList && node.classList.contains('sidebar-content')) break;
+      }
+    }
+
+    input.addEventListener('input', function() {
+      var q = this.value.trim().toLowerCase();
+      if (clearBtn) clearBtn.style.display = q.length > 0 ? 'flex' : 'none';
+
+      if (q.length < 2) {
+        resetFilter();
+        return;
+      }
+
+      // Dim everything, collapse all
+      allItems.forEach(function(li) {
+        li.classList.add('search-dimmed');
+        li.classList.remove('search-match');
+      });
+      document.querySelectorAll('.sidebar .has-children[data-page]').forEach(function(el) {
+        el.classList.remove('expanded');
+        el.classList.add('collapsed');
+        var arrow = el.querySelector('.toggle-arrow');
+        if (arrow) arrow.classList.remove('is-open');
+      });
+
+      // Highlight matches, undim them + parent chain
+      allItems.forEach(function(li) {
+        var textEl = li.querySelector(':scope > a .text');
+        if (!textEl || !li._origText) return;
+        if (li._origText.toLowerCase().indexOf(q) !== -1) {
+          li.classList.remove('search-dimmed');
+          li.classList.add('search-match');
+          expandParentChain(li);
+        }
+      });
+    });
+  })();
 
 </script>
 <!-- End Sidebar -->

--- a/v0/template/pages/main.twig
+++ b/v0/template/pages/main.twig
@@ -5,7 +5,36 @@
   {% include('elements/html-head.twig') %}
 </head>
 <body>
-  {% include('elements/header.twig') %}
+  <div class="top-bar">
+    <button type="button" class="top-bar-burger" onclick="toggleMenu()" aria-label="Toggle menu">
+      <i class="fas fa-bars"></i>
+    </button>
+    <a href="https://www.hubleto.eu" target="_blank" class="top-bar-link top-bar-hubleto">www.hubleto.eu</a>
+    <a href="https://www.reddit.com/r/hubleto/" target="_blank" class="top-bar-link">
+      <i class="fab fa-reddit"></i>
+      <span>Reddit</span>
+    </a>
+    <a href="https://help.hubleto.eu" target="_blank" class="top-bar-link top-bar-desktop">
+      <i class="fas fa-circle-question"></i>
+      <span>User Guide</span>
+    </a>
+    <a href="https://stackoverflow.com/questions/tagged/hubleto" target="_blank" class="top-bar-link top-bar-desktop">
+      <i class="fab fa-stack-overflow"></i>
+      <span>Stack Overflow</span>
+    </a>
+    <a href="https://www.linkedin.com/company/hubleto" target="_blank" class="top-bar-link top-bar-desktop">
+      <i class="fab fa-linkedin"></i>
+      <span>LinkedIn</span>
+    </a>
+    <a href="https://community.hubleto.eu" target="_blank" class="top-bar-link top-bar-desktop">
+      <i class="fas fa-users"></i>
+      <span>Community</span>
+    </a>
+    <a href="https://github.com/hubleto/erp/issues" target="_blank" class="top-bar-link top-bar-desktop">
+      <i class="fab fa-github"></i>
+      <span>Report an issue</span>
+    </a>
+  </div>
   {% include('elements/sidebar.twig') %}
 
 
@@ -50,23 +79,24 @@
         {% endif %}
       {% endif %}
     </div>
+
+    {% if pageConfig.tocData.prevPageData or pageConfig.tocData.nextPageData %}
+      <div class="content flex justify-between">
+        <div class="flex-1 text-left">
+          {% if pageConfig.tocData.prevPageData %}
+            <a href="{{ env.guideRootUrl }}/{{ pageConfig.tocData.prevPageData.page }}">&laquo; Previous page</a><br/>
+            <small>{{ pageConfig.tocData.prevPageData.title }}</small>
+          {% endif %}
+        </div>
+        <div class="flex-1 text-right">
+          {% if pageConfig.tocData.nextPageData %}
+            <a href="{{ env.guideRootUrl }}/{{ pageConfig.tocData.nextPageData.page }}">Next page &raquo;</a><br/>
+            <small>{{ pageConfig.tocData.nextPageData.title }}</small>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
   </div>
-  {% if pageConfig.tocData.prevPageData or pageConfig.tocData.nextPageData %}
-    <div class="content flex justify-between">
-      <div class="flex-1 text-left">
-        {% if pageConfig.tocData.prevPageData %}
-          <a href="{{ env.guideRootUrl }}/{{ pageConfig.tocData.prevPageData.page }}">&laquo; Previous page</a><br/>
-          <small>{{ pageConfig.tocData.prevPageData.title }}</small>
-        {% endif %}
-      </div>
-      <div class="flex-1 text-right">
-        {% if pageConfig.tocData.nextPageData %}
-          <a href="{{ env.guideRootUrl }}/{{ pageConfig.tocData.nextPageData.page }}">Next page &raquo;</a><br/>
-          <small>{{ pageConfig.tocData.nextPageData.title }}</small>
-        {% endif %}
-      </div>
-    </div>
-  {% endif %}
 
   {% include('elements/on-this-page.twig') %}
   {% include('elements/footer.twig') %}


### PR DESCRIPTION
Layout
- added top bar with external links (hubleto.eu, Reddit, Stack Overflow, LinkedIn, Community, GitHub, guide cross-link)
- Content and sidebars now sit in the middle of the page instead of being stuck to the screen edges
- Old header (with breadcrumbs) and footer bar removed

Sidebar
- Soft radial-gradient background replacing the hard border
- Active page shown as a primary-color left accent line (not filled button)
- toggle arrow — clicking it opens/closes the tree without navigating; clicking the text still navigates
- Smooth slide-down animation on expand/collapse
- Sections you manually open stay open across page navigations (localStorage)

Live sidebar search
- Type 2+ characters → non-matching items dim, matching items highlighted in primary color, parent chain auto-expands
- X button to clear, "Press Enter for full search" placeholder hint

- Inline `bg-*-50` card headers in framework/erp/core-architecture pages updated to dark-theme tones